### PR TITLE
test: use fixture HTML for offline scraping

### DIFF
--- a/src/fixtures/example.html
+++ b/src/fixtures/example.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <meta property="og:title" content="Example OG" />
+    <title>Example Domain</title>
+  </head>
+  <body>
+    <p>Hello from fixture</p>
+  </body>
+</html>

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,10 +1,26 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixtureHtml = readFileSync(join(__dirname, 'fixtures/example.html'), 'utf8');
+
+vi.mock('undici', () => ({
+  fetch: async () =>
+    new Response(fixtureHtml, {
+      status: 200,
+      headers: { 'content-type': 'text/html' }
+    })
+}));
+
 import { scrape } from './index';
 
 describe('scrape', () => {
-  it('coleta meta básica de example.com', async () => {
+  it('coleta meta básica do HTML de teste', async () => {
     const r = await scrape('https://example.com');
     expect(r.meta).toBeDefined();
+    expect(r.meta.og?.title).toBe('Example OG');
     expect(r.diagnostics.timingsMs.fetch).toBeGreaterThanOrEqual(0);
   }, 20000);
 });


### PR DESCRIPTION
## Summary
- add fixture HTML to simulate example.com
- mock undici fetch in tests to run without network

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa18da76c0832b84c5896cf123a76c