### PR TITLE
refactor: tighten source key types

### DIFF
--- a/src/core/scrape.ts
+++ b/src/core/scrape.ts
@@ -29,7 +29,7 @@ export async function scrape(url: string, opts: ScrapeOptions = {}): Promise<Scr
     images: useFallbackImgs ? extractFallbackImages($, url) : undefined
   };
 
-  const srcMap: Record<string, 'og' | 'twitter' | 'basic' | 'fallback' | 'none'> = {
+  const srcMap: Record<'title' | 'description' | 'image', 'og' | 'twitter' | 'basic' | 'fallback' | 'none'> = {
     title: og.title ? 'og' : twitter.title ? 'twitter' : basic.title ? 'basic' : 'none',
     description: og.description ? 'og' : twitter.description ? 'twitter' : basic.description ? 'basic' : 'none',
     image: (og.image?.length ? 'og' : twitter.image ? 'twitter' : (fallback.images?.length ? 'fallback' : 'none')),

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,7 @@ export interface ScrapeResult {
     fallback: FallbackMeta;
   };
   diagnostics: {
-    source: Record<string, 'og' | 'twitter' | 'basic' | 'fallback' | 'none'>;
+    source: Record<'title' | 'description' | 'image', 'og' | 'twitter' | 'basic' | 'fallback' | 'none'>;
     timingsMs: { fetch: number; parse: number };
     warnings: string[];
   };


### PR DESCRIPTION
## Summary
- narrow diagnostics.source keys to known meta fields

## Testing
- `pnpm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa18dbfb1c832b8c792d72effb01ec