### PR TITLE
refactor: type for pickBestImage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
+import type { ScrapeResult } from './types';
+
 export * from './types';
 export { scrape } from './core/scrape';
 
-export function pickBestImage(meta: { og?: { image?: string[] }, twitter?: { image?: string }, fallback?: { images?: string[] } }) {
+export function pickBestImage(meta: ScrapeResult['meta']) {
   return meta.og?.image?.[0] || meta.twitter?.image || meta.fallback?.images?.[0];
 }


### PR DESCRIPTION
## Summary
- reuse `ScrapeResult` type for `pickBestImage`

## Testing
- `pnpm test` *(fails: fetch failed)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68aa18f8c75c832b9133f897621a4bd1