### PR TITLE
Resolve relative URLs in basic metadata

### DIFF
--- a/src/core/extract.test.ts
+++ b/src/core/extract.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { load } from 'cheerio';
+import { extractBasic, extractFallbackImages } from './extract';
+
+describe('extractBasic', () => {
+  it('resolves relative favicon and canonical URLs', () => {
+    const html = `
+      <html><head>
+        <title>t</title>
+        <link rel="icon" href="/favicon.ico" />
+        <link rel="canonical" href="/article" />
+      </head></html>
+    `;
+    const $ = load(html);
+    const res = extractBasic($, 'https://example.com/path/page');
+    expect(res.favicon).toBe('https://example.com/favicon.ico');
+    expect(res.canonical).toBe('https://example.com/article');
+  });
+});
+
+describe('extractFallbackImages', () => {
+  it('resolves relative image sources', () => {
+    const html = `
+      <img src="/a.png" />
+      <img src="b.jpg" />
+    `;
+    const $ = load(html);
+    const imgs = extractFallbackImages($, 'https://example.com/blog/');
+    expect(imgs).toContain('https://example.com/a.png');
+    expect(imgs).toContain('https://example.com/blog/b.jpg');
+  });
+});
+

--- a/src/core/extract.ts
+++ b/src/core/extract.ts
@@ -25,11 +25,22 @@ export function extractTwitter($: cheerio.CheerioAPI) {
   };
 }
 
-export function extractBasic($: cheerio.CheerioAPI) {
+export function extractBasic($: cheerio.CheerioAPI, baseUrl: string) {
   const title = $('title').first().text() || undefined;
   const description = $(`meta[name="description"]`).attr('content') || undefined;
-  const favicon = $(`link[rel="icon"]`).attr('href') || $(`link[rel="shortcut icon"]`).attr('href') || undefined;
-  const canonical = $(`link[rel="canonical"]`).attr('href') || undefined;
+  let favicon =
+    $(`link[rel="icon"]`).attr('href') ||
+    $(`link[rel="shortcut icon"]`).attr('href') ||
+    undefined;
+  let canonical = $(`link[rel="canonical"]`).attr('href') || undefined;
+
+  try {
+    if (favicon) favicon = new URL(favicon, baseUrl).toString();
+  } catch {}
+  try {
+    if (canonical) canonical = new URL(canonical, baseUrl).toString();
+  } catch {}
+
   return { title, description, favicon, canonical };
 }
 

--- a/src/core/scrape.ts
+++ b/src/core/scrape.ts
@@ -22,7 +22,7 @@ export async function scrape(url: string, opts: ScrapeOptions = {}): Promise<Scr
 
   const og = extractOg($);
   const twitter = extractTwitter($);
-  const basic = extractBasic($);
+  const basic = extractBasic($, url);
 
   const useFallbackImgs = !(og.image?.length) && !(twitter.image);
   const fallback = {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,10 +1,21 @@
 import { describe, it, expect } from 'vitest';
+import { createServer } from 'http';
 import { scrape } from './index';
 
 describe('scrape', () => {
-  it('coleta meta básica de example.com', async () => {
-    const r = await scrape('https://example.com');
-    expect(r.meta).toBeDefined();
+  it('coleta meta básica de página local', async () => {
+    const html = `<!doctype html><html><head><title>Hello</title><meta name="description" content="desc"><link rel="icon" href="/favicon.ico"><link rel="canonical" href="/canon"></head><body></body></html>`;
+    const server = createServer((_, res) => {
+      res.writeHead(200, { 'content-type': 'text/html' });
+      res.end(html);
+    });
+    await new Promise(resolve => server.listen(0, resolve));
+    const { port } = server.address() as any;
+    const url = `http://127.0.0.1:${port}/path/page`;
+    const r = await scrape(url);
+    server.close();
+    expect(r.meta.basic.favicon).toBe(`http://127.0.0.1:${port}/favicon.ico`);
+    expect(r.meta.basic.canonical).toBe(`http://127.0.0.1:${port}/canon`);
     expect(r.diagnostics.timingsMs.fetch).toBeGreaterThanOrEqual(0);
   }, 20000);
 });


### PR DESCRIPTION
## Summary
- resolve `favicon` and `canonical` against page URL in `extractBasic`
- update `scrape` to pass page URL to `extractBasic`
- add tests for relative URL handling and replace network test with local server

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa18fefbbc832bb217a765a5576627