### PR TITLE
feat: parse manifest icons

### DIFF
--- a/src/iconPicker.ts
+++ b/src/iconPicker.ts
@@ -1,0 +1,89 @@
+import { load as loadHtml } from 'cheerio';
+import { fetch } from 'undici';
+
+export interface IconCandidate {
+  url: string;
+  sizes?: string;
+  type?: string;
+  purpose?: string;
+  score?: number;
+}
+
+export function normalizeImageUrl(src: string, baseUrl: string): string | undefined {
+  try {
+    const url = new URL(src, baseUrl);
+    if (url.protocol === 'http:' || url.protocol === 'https:') {
+      return url.toString();
+    }
+  } catch {
+    // ignore invalid URLs
+  }
+  return undefined;
+}
+
+export function scoreIcon(icon: IconCandidate): number {
+  let score = 0;
+  if (icon.sizes) {
+    const sizes = icon.sizes
+      .split(/\s+/)
+      .map(s => {
+        const [w, h] = s.split('x').map(n => parseInt(n, 10));
+        return Math.max(w || 0, h || 0);
+      })
+      .filter(n => !isNaN(n));
+    const maxSize = sizes.length ? Math.max(...sizes) : 0;
+    score += maxSize;
+  }
+  if (icon.purpose?.includes('maskable')) score += 1000;
+  if (icon.type === 'image/svg+xml') score += 500;
+  return score;
+}
+
+export async function pickIcons(url: string): Promise<IconCandidate[]> {
+  const res = await fetch(url, { headers: { accept: 'text/html,*/*' } });
+  if (!res.ok) return [];
+  const html = await res.text();
+  const $ = loadHtml(html);
+  const baseUrl = res.url;
+
+  const candidates: IconCandidate[] = [];
+
+  const add = (c: IconCandidate) => {
+    c.url = normalizeImageUrl(c.url, baseUrl) || c.url;
+    c.score = scoreIcon(c);
+    candidates.push(c);
+  };
+
+  $('link[rel~="icon"]').each((_, el) => {
+    const href = $(el).attr('href');
+    if (!href) return;
+    const normalized = normalizeImageUrl(href, baseUrl);
+    if (!normalized) return;
+    add({ url: normalized, sizes: $(el).attr('sizes'), type: $(el).attr('type') || undefined });
+  });
+
+  const manifestHref = $('link[rel="manifest"]').attr('href');
+  if (manifestHref) {
+    const manifestUrl = normalizeImageUrl(manifestHref, baseUrl);
+    if (manifestUrl) {
+      try {
+        const manRes = await fetch(manifestUrl, { headers: { accept: 'application/manifest+json,application/json' } });
+        if (manRes.ok) {
+          const manifest = await manRes.json();
+          if (Array.isArray(manifest.icons)) {
+            for (const icon of manifest.icons) {
+              if (!icon.src) continue;
+              const src = normalizeImageUrl(icon.src, manifestUrl);
+              if (!src) continue;
+              add({ url: src, sizes: icon.sizes, type: icon.type, purpose: icon.purpose });
+            }
+          }
+        }
+      } catch {
+        // ignore manifest fetch errors
+      }
+    }
+  }
+
+  return candidates.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import type { ScrapeResult } from './types';
 
 export * from './types';
 export { scrape } from './core/scrape';
+export { pickIcons } from './iconPicker';
 
 export function pickBestImage(meta: ScrapeResult['meta']) {
   return meta.og?.image?.[0] || meta.twitter?.image || meta.fallback?.images?.[0];

--- a/test/scrape.test.ts
+++ b/test/scrape.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import { scrape } from './index';
+import { scrape } from '../src/index';
 
 // Test that fallback images are resolved against the final URL after redirects
 // to ensure relative image paths are correct even when the initial URL redirects.


### PR DESCRIPTION
## Summary
- add iconPicker module that fetches web manifest icons and scores them
- expose `pickIcons` in public index
- adjust tests to resolve root index

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68ad65f2e750832bb3a01b949bf42f10