### PR TITLE
feat: score icons without sizes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import type { ScrapeResult } from './types';
 
 export * from './types';
 export { scrape } from './core/scrape';
+export { scoreIcon } from './score-icon';
 
 export function pickBestImage(meta: ScrapeResult['meta']) {
   return meta.og?.image?.[0] || meta.twitter?.image || meta.fallback?.images?.[0];

--- a/src/score-icon.ts
+++ b/src/score-icon.ts
@@ -1,0 +1,10 @@
+export interface IconCandidate {
+  sizes?: number[];
+}
+
+// Scores icon candidates based on closeness to a target size.
+// Defaults to assuming a 32px icon when no sizes are provided.
+export function scoreIcon(c: IconCandidate, target = 32): number {
+  const best = c.sizes?.[0] ?? 32;
+  return 1 / (1 + Math.abs(best - target));
+}

--- a/test/score-icon.test.ts
+++ b/test/score-icon.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { scoreIcon } from '../src';
+
+describe('scoreIcon', () => {
+  it('uses provided sizes when scoring', () => {
+    // icon exactly at target size should score highest (1)
+    expect(scoreIcon({ sizes: [32] })).toBe(1);
+  });
+
+  it('defaults to 32px when no sizes are provided', () => {
+    // without sizes, we assume 32px which yields same score as a 32px icon
+    expect(scoreIcon({})).toBe(1);
+  });
+});

--- a/test/scrape.test.ts
+++ b/test/scrape.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import { scrape } from './index';
+import { scrape } from '../src';
 
 // Test that fallback images are resolved against the final URL after redirects
 // to ensure relative image paths are correct even when the initial URL redirects.


### PR DESCRIPTION
## Summary
- export new `scoreIcon` utility and default icon scoring to 32px when no size is provided
- cover icon scoring with tests including icons lacking size information
- fix test import path for scraping fallback images

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68ad6611c520832b9f399f2d347e183d